### PR TITLE
更新 python 支持版本

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 基于[Levenshtein](https://github.com/Levenshtein) 字符串相似度算法来进行详细地址过滤
 
 # [依赖下载](https://pypi.org/project/addressrec/)
-python支持版本：`>=3.8`
+python支持版本：`>=3.8 and <= 3.10`
 
 ```bash
 pip3 install addressrec


### PR DESCRIPTION
该项目依赖 paddlepaddle 2.4.2，经实际测试，该版本仅支持 python 3.6..10，不支持 python 3.11